### PR TITLE
expose wol as a module of the package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           )
           mkdir -p artifacts
 
+          rm -r -f /home/runner/.cache/zig
           zig fetch --save git+https://github.com/Hejsil/zig-clap
           
           for tgt in "${targets[@]}"; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
           )
           mkdir -p artifacts
 
+          zig fetch --save git+https://github.com/Hejsil/zig-clap
+          
           for tgt in "${targets[@]}"; do
             zig build -Dtarget="$tgt" --release=small --prefix "zig-out/$tgt"
             binpath="zig-out/$tgt/bin"

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .zigwol,
     .fingerprint = 0xde77714c68dfba75,
-    .version = "0.4.1",
+    .version = "0.4.2",
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .clap = .{
@@ -13,5 +13,6 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "LICENSE",
     },
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const clap = @import("clap");
-const wol = @import("wol.zig");
-const alias = @import("alias.zig");
+const clap = @import("clap"); // third-party lib for cmd line args parsing
+const wol = @import("wol"); // local module
+const alias = @import("alias.zig"); // local src file
 
-const version = "0.4.1"; // should be read from build.zig.zon at comptime
+const version = "0.4.2"; // should be read from build.zig.zon at comptime
 
 // Implement the subcommands parser
 const SubCommands = enum {

--- a/src/wol.zig
+++ b/src/wol.zig
@@ -63,7 +63,7 @@ test "is_mac_valid" {
     try std.testing.expectEqual(is_mac_valid(""), false); // Empty string
 }
 
-fn generate_magic_packet(mac_bytes: [6]u8) [102]u8 {
+pub fn generate_magic_packet(mac_bytes: [6]u8) [102]u8 {
     var packet: [102]u8 = undefined;
     @memset(packet[0..6], 0xFF); // First 6 bytes are 0xFF
     for (0..16) |i| {


### PR DESCRIPTION
allows other projects to fetch zig-wol repo as a dependency and add wol as a module from the dependency then use it simply by @import("wol")

Closes #20 